### PR TITLE
Typo correction in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -3377,7 +3377,7 @@ function getDbInfo()
    /* prepare statement using PDO*/
    global $dbconn;
    global $DATABASE;
-   global $DB_HOST1;
+   global $DB_HOST;
    global $DB_USER;
    global $DB_PASS;
    global $dbconn;


### PR DESCRIPTION
Typo causes problem with mysql server info gathering when used remote database host. 

Debug info: HTTP/1.1 500 Internal Server Error Error (getDbInfo) Message: SQLSTATE[HY000] [2002] Can't connect to local MySQL server through socket '/var/lib/mysql/mysql.sock' (2) Error (getDbInfo) getTraceAsString: #0 /usr/local/waf-fle/functions.php(3429): PDO->__construct('mysql:host=;dbn...', 'someuser', 'somepass') #1 /usr/local/waf-fle/dashboard/management.php(424): getDbInfo() #2 {main}
