### PR TITLE
Better url path and query handling

### DIFF
--- a/controller/index.php
+++ b/controller/index.php
@@ -120,9 +120,9 @@ while ( $line < $BodySize) {
             } else {
                 if (preg_match('/^(GET|POST|HEAD|PUT|DELETE|TRACE|PROPFIND|OPTIONS|CONNECT|PATCH)\s(.+)\s(HTTP\/[01]\.[019])/i', trim($BODY[$line]), $matchesB)) {
                     $PhaseB['Method']        = $matchesB[1];
-                    $PhaseB['pathParameter'] = parse_url($matchesB[2], PHP_URL_QUERY);
+                    $PhaseB['pathParameter'] = parse_url("http://dummy.ex".$matchesB[2], PHP_URL_QUERY);
                     // $pathParsed              = parse_url($matchesB[2], PHP_URL_PATH);
-                    $PhaseB['path']          = parse_url($matchesB[2], PHP_URL_PATH);
+                    $PhaseB['path']          = parse_url("http://dummy.ex".$matchesB[2], PHP_URL_PATH);
                     $PhaseB['Protocol']      = $matchesB[3];
                 } elseif (preg_match('/^Host:\s(.+)/i', trim($BODY[$line]), $matchesB)) {
                     $PhaseB['Host'] = $matchesB[1];


### PR DESCRIPTION
parse_url php function handles url path and query better when protocol://host section is present. Adding dummy protocol://host section improves url parsing for example when there is another URL in the query. For example /?path=http://thaitacticalgear.com//live/wp-includes/images/t.gif??' is not parsed correctly without this change. This change solves the issue 16 at http://code.google.com/p/waf-fle/issues/
