### PR TITLE
Messages handling improvement

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -49,6 +49,11 @@ $SESSION_TIMEOUT = 600;
 // default is "true"
 $GetSensorInfo = true;
 
+// Set rule id number for "Execution Error - PCRE limit exceeded" message.
+// This number must not be used in any other rule id;
+// Default: 1
+$PcreErrRuleId = 1;
+
 // Debug enable/disable
 $DEBUG = false;
 

--- a/functions.php
+++ b/functions.php
@@ -25,6 +25,11 @@ ini_set('display_errors', 0);
 // Print errors in php log (normally apache errors log), but not notice logs
 error_reporting(E_ALL ^ E_NOTICE);
 
+// $PcreErrRuleId handling;
+if (!isset($PcreErrRuleId) OR !preg_match('/^\d+$/', $PcreErrRuleId)) {
+    $PcreErrRuleId = 1;
+}
+
 if (is_readable("../config.php")) {
     require_once "config.php";
 } else {


### PR DESCRIPTION
This patch adds "detected SQLi using libinjection with fingerprint" message handling and "Execution Error - PCRE limit exceeded" message handling in controller/index.php.
Added possibility to define explicit rule number for "Execution Error - PCRE limit exceeded" message, so it will be possible to search for this event in database.
