### PR TITLE
Added possibility to choose which IP address from IP header will be used

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -54,6 +54,12 @@ $GetSensorInfo = true;
 // Default: 99999
 $PcreErrRuleId = 99999;
 
+// Set this variable to true if you want to chose the last IP address as 
+// original address from the header you have defined as Client IP 
+// in the sensor configuration page.
+// Default is false.
+$IPHeaderUseLast = false;
+
 // Debug enable/disable
 $DEBUG = false;
 

--- a/controller/index.php
+++ b/controller/index.php
@@ -60,7 +60,11 @@ if ($login_status['status'] == 1) {
     exit();
 }
 if ($login_status['sensor_client_ip_header'] != "") {
-	$clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":\s([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})";
+    if (isset($IPHeaderUseLast) AND $IPHeaderUseLast) {
+        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":.+([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})$";
+    } else {
+        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":\s([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})";
+    }
 }
 
 // Body: read and treatment

--- a/controller/index.php
+++ b/controller/index.php
@@ -61,9 +61,9 @@ if ($login_status['status'] == 1) {
 }
 if ($login_status['sensor_client_ip_header'] != "") {
     if (isset($IPHeaderUseLast) AND $IPHeaderUseLast) {
-        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":.+([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})$";
+        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":\s([0-9.]+,\s)*([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})$";
     } else {
-        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":\s([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})";
+        $clientIpHeaderRegExp = "^".$login_status['sensor_client_ip_header'].":(\s)([12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2}\.[12]?[0-9]{1,2})";
     }
 }
 
@@ -136,7 +136,7 @@ while ( $line < $BodySize) {
                 } elseif (preg_match('/^User-Agent:\s(.+)/i', trim($BODY[$line]), $matchesB)) {
                     $PhaseB['User-Agent'] = $matchesB[1];
                 } elseif ($login_status['sensor_client_ip_header'] != "" AND preg_match("/$clientIpHeaderRegExp/i", trim($BODY[$line]), $matchesB)) {
-                    $PhaseA['ClientIP'] = $matchesB[1];  // Set Client IP (to Phase A) when a HTTP Header is defined to carry real client ip, and sensor are marked to respect this
+                    $PhaseA['ClientIP'] = $matchesB[2];  // Set Client IP (to Phase A) when a HTTP Header is defined to carry real client ip, and sensor are marked to respect this
                 }
                 
                 $PhaseB_full = $PhaseB_full . $BODY[$line];


### PR DESCRIPTION
When Client IP from header is checked (in sensor config), there are some situations where
it is not desirable choose first IP as original Client IP. This patch is useful for example
if you are behind proxy or load balancer and you are not interested in realy original IP address,
but in the same time you want to view IP address that adds your proxy for your server.