### PR TITLE
Fixed modsecurity.conf templating of mlogc feeder

### DIFF
--- a/dashboard/wizardfeeder.php
+++ b/dashboard/wizardfeeder.php
@@ -158,7 +158,7 @@ SecAuditLogParts ABIDEFGHZ
 #
 SecAuditLogType Concurrent
 
-SecAuditLog /var/log/mlogc/modsec_audit.log
+SecAuditLog <?PHP print headerprintnobr($_GET['logfile']) . "\n"; ?>
 
 # Specify the path for concurrent audit logging.
 SecAuditLogStorageDir <?PHP print headerprintnobr($_GET['logdir']) ."\n"; ?>


### PR DESCRIPTION
I replaced hard coded value to variable.

Templates generated for:
Feeder: mlogc 
Usage: scheduled 

Please check this commit.
Thanks.